### PR TITLE
Unmarshal fixes

### DIFF
--- a/util/reflect.go
+++ b/util/reflect.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/kylelemons/godebug/pretty"
 	"github.com/openconfig/goyang/pkg/yang"
 
 	log "github.com/golang/glog"
@@ -210,8 +209,8 @@ func InsertIntoSlice(parentSlice interface{}, value interface{}) error {
 
 // InsertIntoMap inserts value with key into parent which must be a map.
 func InsertIntoMap(parentMap interface{}, key interface{}, value interface{}) error {
-	DbgPrint("InsertIntoMap into parent type %T with key %v(%T) value \n%s\n (%T)",
-		parentMap, ValueStrDebug(key), key, pretty.Sprint(value), value)
+	// DbgPrint("InsertIntoMap into parent type %T with key %v(%T) value \n%s\n (%T)",
+	// parentMap, ValueStrDebug(key), key, pretty.Sprint(value), value)
 
 	v := reflect.ValueOf(parentMap)
 	t := reflect.TypeOf(parentMap)

--- a/ytypes/container.go
+++ b/ytypes/container.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	log "github.com/golang/glog"
-	"github.com/kylelemons/godebug/pretty"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/util"
 	"github.com/openconfig/ygot/yext"
@@ -258,7 +257,7 @@ func unmarshalStruct(schema *yang.Entry, parent interface{}, jsonTree map[string
 		}
 	}
 
-	util.DbgPrint("container after unmarshal:\n%s\n", pretty.Sprint(destv.Interface()))
+	// util.DbgPrint("container after unmarshal:\n%s\n", pretty.Sprint(destv.Interface()))
 	return nil
 }
 

--- a/ytypes/list.go
+++ b/ytypes/list.go
@@ -337,22 +337,21 @@ func unmarshalList(schema *yang.Entry, parent interface{}, jsonList interface{},
 
 		switch {
 		case util.IsTypeMap(t):
-			var newKey reflect.Value
-			// var present bool
+			var (
+				newKey  reflect.Value
+				present bool
+			)
 			newKey, err = makeKeyForInsert(schema, parent, newVal)
 			if err != nil {
 				return err
 			}
-			// TODO(ythadhani) Uncomment once express passes
-			/*
-				present, err = util.MapContainsKey(parent, newKey.Interface())
-				if err != nil {
-					return err
-				}
-				if present {
-					return fmt.Errorf("duplicate value: %v encountered for key(s): %s of list: %s", newKey.Interface(), schema.Key, schema.Name)
-				}
-			*/
+			present, err = util.MapContainsKey(parent, newKey.Interface())
+			if err != nil {
+				return err
+			}
+			if present {
+				return fmt.Errorf("duplicate value: '%v' encountered for key(s): '%s' of list: '%s'", newKey.Interface(), schema.Key, schema.Name)
+			}
 			err = util.InsertIntoMap(parent, newKey.Interface(), newVal.Interface())
 		case util.IsTypeSlicePtr(t):
 			err = util.InsertIntoSlice(parent, newVal.Interface())

--- a/ytypes/list.go
+++ b/ytypes/list.go
@@ -19,7 +19,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/kylelemons/godebug/pretty"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/util"
 )
@@ -362,7 +361,7 @@ func unmarshalList(schema *yang.Entry, parent interface{}, jsonList interface{},
 			return err
 		}
 	}
-	util.DbgPrint("list after unmarshal:\n%s\n", pretty.Sprint(parent))
+	// util.DbgPrint("list after unmarshal:\n%s\n", pretty.Sprint(parent))
 
 	return nil
 }


### PR DESCRIPTION
1. Commenting out occurrences of pretty.Sprint. Memory leak detected.
2. Checking duplicate keys during unmarshal into keyed lists.