### PR TITLE
Fixing SetNode for leafrefs as keys of keyed-lists

### DIFF
--- a/util/path.go
+++ b/util/path.go
@@ -223,9 +223,9 @@ func firstMatching(schema *yang.Entry, path []string) *yang.Entry {
 	return s
 }
 
-// removeXPATHPredicates removes predicates from an XPath string. e.g.,
-// removeXPATHPredicates(/foo/bar[name="foo"]/config/baz -> /foo/bar/config/baz.
-func removeXPATHPredicates(s string) (string, error) {
+// RemoveXPATHPredicates removes predicates from an XPath string. e.g.,
+// RemoveXPATHPredicates(/foo/bar[name="foo"]/config/baz) -> /foo/bar/config/baz.
+func RemoveXPATHPredicates(s string) (string, error) {
 	var b bytes.Buffer
 	for i := 0; i < len(s); {
 		ss := s[i:]
@@ -266,7 +266,7 @@ func FindLeafRefSchema(schema *yang.Entry, pathStr string) (*yang.Entry, error) 
 	}
 
 	refSchema := schema
-	pathStr, err := removeXPATHPredicates(pathStr)
+	pathStr, err := RemoveXPATHPredicates(pathStr)
 	if err != nil {
 		return nil, err
 	}

--- a/util/path_test.go
+++ b/util/path_test.go
@@ -473,7 +473,7 @@ func TestRemoveXPATHPredicates(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			got, err := removeXPATHPredicates(tt.in)
+			got, err := RemoveXPATHPredicates(tt.in)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("removeXPATHPredicates(%s): got unexpected error, got: %v", tt.in, err)
 			}
@@ -850,7 +850,6 @@ func TestStripModulePrefix(t *testing.T) {
 			if got, want := StripModulePrefix(tt.inName), tt.wantName; got != want {
 				t.Errorf("StripModulePrefix(%v): did not get expected name, got: %s, want: %s", tt.inName, got, want)
 			}
-
 		})
 	}
 }
@@ -945,7 +944,6 @@ func TestReplacePathSuffix(t *testing.T) {
 			if got != tt.wantName {
 				t.Errorf("ReplacePathSuffix(%v, %v): did not get expected name, got: %s, want: %s", tt.inName, tt.inNewSuffix, got, tt.wantName)
 			}
-
 		})
 	}
 }

--- a/ytypes/list.go
+++ b/ytypes/list.go
@@ -82,15 +82,17 @@ func validateList(schema *yang.Entry, value interface{}) util.Errors {
 
 // checkKeys checks that the map key value for the list equals the value of the
 // key field(s) in the elements for the map value.
-//   entry is the schema for the list.
-//   structElems is the structure representing the element in the data tree.
-//   keyElems is the structure representing the map key in the data tree.
+//
+//	entry is the schema for the list.
+//	structElems is the structure representing the element in the data tree.
+//	keyElems is the structure representing the map key in the data tree.
+//
 // For a list schema that has a struct key, it's expected that:
-//    1. The schema contains leaves with the struct field names (checked before
-//       calling this function).
-//    2. Each element in the list has key fields defined by the leaves in 1.
-//    3. For each such key field, the field value in the element equals the
-//       value of the map key of the containing map in the data tree.
+//  1. The schema contains leaves with the struct field names (checked before
+//     calling this function).
+//  2. Each element in the list has key fields defined by the leaves in 1.
+//  3. For each such key field, the field value in the element equals the
+//     value of the map key of the containing map in the data tree.
 func checkKeys(schema *yang.Entry, structElems reflect.Value, keyValue reflect.Value) util.Errors {
 	keys := strings.Fields(schema.Key)
 	if len(keys) == 1 {
@@ -131,9 +133,9 @@ func checkBasicKeyValue(structElems reflect.Value, keyFieldSchemaName string, ke
 
 // checkStructKeyValues checks that the provided key struct (which is the key
 // value of the entry in the data tree map):
-//  - has all the fields defined in the schema key definition
-//  - has no fields not defined in the schema key definition
-//  - has values for each field equal to the corresponding field in the element.
+//   - has all the fields defined in the schema key definition
+//   - has no fields not defined in the schema key definition
+//   - has values for each field equal to the corresponding field in the element.
 func checkStructKeyValues(structElems reflect.Value, keyStruct reflect.Value) util.Errors {
 	var errors []error
 	if keyStruct.Type().Kind() != reflect.Struct {
@@ -269,11 +271,12 @@ func nameMatchesPath(fieldName string, path []string) (bool, error) {
 
 // unmarshalList unmarshals a JSON array into a list parent, which must be a
 // map or slice ptr.
-//   schema is the schema of the schema node corresponding to the struct being
-//     unmamshaled into
-//   jsonList is a JSON list
-//   opts... are a set of ytypes.UnmarshalOptionst that are used to control
-//     the behaviour of the unmarshal function.
+//
+//	schema is the schema of the schema node corresponding to the struct being
+//	  unmamshaled into
+//	jsonList is a JSON list
+//	opts... are a set of ytypes.UnmarshalOptionst that are used to control
+//	  the behaviour of the unmarshal function.
 func unmarshalList(schema *yang.Entry, parent interface{}, jsonList interface{}, enc Encoding, opts ...UnmarshalOpt) error {
 	if util.IsValueNil(jsonList) {
 		return nil
@@ -400,7 +403,10 @@ func makeValForInsert(schema *yang.Entry, parent interface{}, keys map[string]st
 			return fmt.Errorf("missing %q key in schema directory %v", keySchemaName, schema.Dir)
 		}
 		if keySchema.Type.Kind == yang.Yleafref {
-			leafrefPath := keySchema.Type.Path
+			leafrefPath, err := util.RemoveXPATHPredicates(keySchema.Type.Path)
+			if err != nil {
+				return err
+			}
 			switch {
 			case leafrefPath[0] == '/':
 				// If this is an absolute path, we need to implement this search without Find, since


### PR DESCRIPTION
In call to SetNode, ignore predicates in a leafref path of a leaf that is the key of a keyed-list.